### PR TITLE
Update CoffeeScriptRhinoCompiler.java

### DIFF
--- a/src/coffeescript/nb/CoffeeScriptRhinoCompiler.java
+++ b/src/coffeescript/nb/CoffeeScriptRhinoCompiler.java
@@ -56,7 +56,12 @@ public class CoffeeScriptRhinoCompiler implements CoffeeScriptCompiler {
                 String message = (String) ScriptableObject.getProperty(error, "message");
                 IdScriptableObject location = (IdScriptableObject) ScriptableObject.getProperty(error, "location");
                 Double line = (Double) ScriptableObject.getProperty(location, "first_line");
-                Double column = (Double) ScriptableObject.getProperty(location, "first_column");
+                Double column;
+                if(col instanceof Integer) {
+                    column = ((Integer)col).doubleValue();
+                } else {
+                    column = (Double)col;
+                }
                 return new CompilerResult(new Error(line == null ? -1 : line.intValue()+1, column == null ? 0 : column.intValue()+1, message, message));
             }
             return new CompilerResult(new Error(-1, "", e.getMessage()));


### PR DESCRIPTION
Sometimes ScriptableObject.getProperty(location, "first_line") return an Integer (so can't cast Integer to Double) that fix it

like this case:

class test
  constructor:() ->
    @fail_case : { test: 0 }
